### PR TITLE
[CPU] Full Instructions Impl

### DIFF
--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_00E0.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_00E0.kt
@@ -1,0 +1,21 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: 00E0 - CLS (Clearing Display)
+
+    Clears the CHIP-8 display. This is typically used at the start of a
+    program or game to initialize the screen.
+*/
+class Instruction_00E0 : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        core.display.clear()
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_00EE.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_00EE.kt
@@ -1,0 +1,23 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: 00EE - RET (Return)
+    Returns from a subroutine call. This is the counterpart to "2nnn - CALL addr".
+
+    CHIP-8 uses a manual stack for managing function calls (subroutines).
+    This instruction allows execution to return to the point after the CALL.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_00EE : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        cpu.sp--
+        cpu.pc = cpu.stack[cpu.sp.toInt()]
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_0NNN.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_0NNN.kt
@@ -1,0 +1,21 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: 0NNN - SYS addr
+
+    Originally used to call machine code routines at address NNN.
+    This instruction is ignored by modern CHIP-8 interpreters.
+    Common practice is to treat it as a NOP (No Operation).
+*/
+class Instruction_0NNN : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        cpu.pc = (cpu.pc + 2u).toUShort() // Ignored, treat as NOP
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_1NNN.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_1NNN.kt
@@ -1,0 +1,20 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: 1NNN - JP addr (Jump)
+    Sets the Program Counter (PC) to nnn.
+
+    This is a fundamental control flow instruction used to move execution.
+*/
+class Instruction_1NNN : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        cpu.pc = opcode.nnn
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_2NNN.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_2NNN.kt
@@ -1,0 +1,24 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: 2NNN - CALL addr
+    Call subroutine at address nnn.
+
+    Stores the current program counter (PC + 2) on the stack,
+    increments the stack pointer (SP), and then sets the program counter to nnn.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_2NNN : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        cpu.stack[cpu.sp.toInt()] = (cpu.pc + 2u).toUShort()
+        cpu.sp++
+        cpu.pc = opcode.nnn
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_3XKK.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_3XKK.kt
@@ -1,0 +1,23 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: 3XKK - SE Vx, byte
+    Skip the next instruction if Vx == kk
+
+    Compares the value in register Vx with the immediate byte kk.
+    If equal, increment PC by 4 (skipping the next instruction).
+    Otherwise, increment PC by 2 (continue as normal).
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_3XKK : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        cpu.pc = (cpu.pc + (if (cpu.v[opcode.x.toInt()] == opcode.kk) 4u else 2u)).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_4XKK.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_4XKK.kt
@@ -1,0 +1,23 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: 4XKK - SNE Vx, byte
+    Skip next instruction if Vx != kk.
+
+    Compares register Vx to kk, and if they are not equal,
+    it increments the program counter by 4 to skip the next instruction.
+    Otherwise, it proceeds normally (adds 2).
+*/
+class Instruction_4XKK : Instruction {
+    @OptIn(ExperimentalUnsignedTypes::class)
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        cpu.pc = (cpu.pc + if (cpu.v[opcode.x.toInt()] != opcode.kk) 4u else 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_5XY0.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_5XY0.kt
@@ -1,0 +1,25 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: 5XY0 - SE Vx, Vy
+    Skip next instruction if Vx == Vy.
+
+    Compares register Vx to register Vy, and if they are equal,
+    it increments the program counter by 4 to skip the next instruction.
+    Otherwise, it proceeds normally (adds 2).
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_5XY0 : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        val x = opcode.x.toInt()
+        val y = opcode.y.toInt()
+        cpu.pc = (cpu.pc + if (cpu.v[x] == cpu.v[y]) 4u else 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_6XKK.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_6XKK.kt
@@ -1,0 +1,23 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: 6XKK - LD Vx, byte
+    Set Vx = kk.
+
+    Stores the 8-bit constant kk into register Vx.
+    This is typically used to initialize or reset register values.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_6XKK : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        cpu.v[opcode.x.toInt()] = opcode.kk
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_7XKK.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_7XKK.kt
@@ -1,0 +1,24 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: 7XKK - ADD Vx, byte
+    Set Vx = Vx + kk.
+
+    Adds the 8-bit constant kk to the value of register Vx, and stores the result in Vx.
+    This operation does not affect the carry flag (VF). Only the lower 8 bits are kept.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_7XKK : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        val x = opcode.x.toInt()
+        cpu.v[x] = ((cpu.v[x] + opcode.kk) and 0xFFu).toUByte()
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_8XY0.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_8XY0.kt
@@ -1,0 +1,22 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: 8XY0 - LD Vx, Vy
+    Set Vx = Vy.
+
+    Copies the value of register Vy into register Vx.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_8XY0 : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        cpu.v[opcode.x.toInt()] = cpu.v[opcode.y.toInt()]
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_8XY1.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_8XY1.kt
@@ -1,0 +1,26 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: 8XY1 - OR Vx, Vy
+    Set Vx = Vx OR Vy.
+
+    Performs a bitwise OR operation on the values of Vx and Vy,
+    then stores the result in Vx. The OR operation compares each
+    bit of the two operands; if either bit is 1, the result is 1.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_8XY1 : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        val x = opcode.x.toInt()
+        val y = opcode.y.toInt()
+        cpu.v[x] = cpu.v[x] or cpu.v[y]
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_8XY2.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_8XY2.kt
@@ -1,0 +1,25 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: 8XY2 - AND Vx, Vy
+    Set Vx = Vx AND Vy.
+
+    Performs a bitwise AND on the values of Vx and Vy,
+    then stores the result in Vx.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_8XY2 : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        val x = opcode.x.toInt()
+        val y = opcode.y.toInt()
+        cpu.v[x] = cpu.v[x] and cpu.v[y]
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_8XY3.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_8XY3.kt
@@ -1,0 +1,25 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: 8XY3 - XOR Vx, Vy
+    Set Vx = Vx XOR Vy.
+
+    Performs a bitwise exclusive OR (XOR) on the values of Vx and Vy,
+    then stores the result in Vx.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_8XY3 : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        val x = opcode.x.toInt()
+        val y = opcode.y.toInt()
+        cpu.v[x] = cpu.v[x] xor cpu.v[y]
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_8XY4.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_8XY4.kt
@@ -1,0 +1,28 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction8XY4 - ADD Vx, Vy
+    Set Vx = Vx + Vy, set VF = carry.
+
+    Adds the values of Vx and Vy. If the result is greater than 255 (8 bits),
+    then VF (V[0xF]) is set to 1 to indicate a carry occurred. Otherwise, VF is set to 0.
+    Only the lower 8 bits of the result are stored back in Vx.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_8XY4 : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        val x = opcode.x.toInt()
+        val y = opcode.y.toInt()
+        val sum = cpu.v[x] + cpu.v[y]
+        cpu.v[0xF] = if (sum > 0xFFu) 1u else 0u
+        cpu.v[x] = (sum and 0xFFu).toUByte()
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_8XY5.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_8XY5.kt
@@ -1,0 +1,27 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: 8XY5 - SUB Vx, Vy
+    Set Vx = Vx - Vy, set VF = NOT borrow.
+
+    Subtracts the value of register Vy from register Vx.
+    If Vx > Vy, VF (V[0xF]) is set to 1 to indicate NO borrow.
+    Otherwise, VF is set to 0 (borrow occurred).
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_8XY5 : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        val x = opcode.x.toInt()
+        val y = opcode.y.toInt()
+        cpu.v[0xF] = if (cpu.v[x] > cpu.v[y]) 1u else 0u
+        cpu.v[x] = ((cpu.v[x] - cpu.v[y]) and 0xFFu).toUByte()
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_8XY6.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_8XY6.kt
@@ -1,0 +1,26 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: 8XY6 - SHR Vx {, Vy}
+    Set Vx = Vx >> 1. Set VF to least significant bit prior to shift.
+
+    This instruction shifts the value of Vx right by one (division by 2).
+    Before the shift, the least significant bit (LSB) is saved into VF (V[0xF]),
+    then the result is stored back into Vx.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_8XY6 : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        val x = opcode.x.toInt()
+        cpu.v[0xF] = (cpu.v[x].toInt() and 0x1).toUByte()
+        cpu.v[x] = (cpu.v[x].toInt() shr 1).toUByte()
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_8XY7.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_8XY7.kt
@@ -1,0 +1,26 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: 8XY7 - SUBN Vx, Vy
+    Set Vx = Vy - Vx, set VF = NOT borrow.
+
+    The values of Vy and Vx are compared. If Vy > Vx, VF is set to 1 (no borrow), otherwise 0.
+    Then Vx is assigned the result of Vy - Vx.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_8XY7 : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        val x = opcode.x.toInt()
+        val y = opcode.y.toInt()
+        cpu.v[0xF] = if (cpu.v[y] > cpu.v[x]) 1u else 0u
+        cpu.v[x] = ((cpu.v[y] - cpu.v[x]) and 0xFFu).toUByte()
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_8XYE.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_8XYE.kt
@@ -1,0 +1,26 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: 8XYE - SHL Vx {, Vy}
+    Set Vx = Vx SHL 1.
+
+    Shift the value in register Vx left by one bit. 
+    Store the most significant bit of Vx in VF before the shift.
+    Then store the shifted result (Vx * 2) back into Vx.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_8XYE : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        val x = opcode.x.toInt()
+        cpu.v[0xF] = ((cpu.v[x].toInt() shr 7) and 0x1).toUByte()
+        cpu.v[x] = ((cpu.v[x].toInt() shl 1) and 0xFF).toUByte()
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_9XY0.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_9XY0.kt
@@ -1,0 +1,25 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: 9XY0 - SNE Vx, Vy
+    Skip next instruction if Vx != Vy.
+
+    The values of Vx and Vy are compared. If they are not equal,
+    the program counter (PC) is increased by 4 to skip the next instruction.
+    Otherwise, PC is increased by 2 as usual.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_9XY0 : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        val x = opcode.x.toInt()
+        val y = opcode.y.toInt()
+        cpu.pc = (cpu.pc + (if (cpu.v[x] != cpu.v[y]) 4u else 2u)).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_ANNN.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_ANNN.kt
@@ -1,0 +1,21 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: ANNN - LD I, addr
+    Set I = nnn.
+
+    Loads the immediate address (nnn) into the index register I.
+*/
+class Instruction_ANNN : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        cpu.index = opcode.nnn
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_BNNN.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_BNNN.kt
@@ -1,0 +1,23 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: BNNN - JP V0, addr
+    Jump to location nnn + V0.
+
+    This instruction sets the program counter (PC) to the value of nnn
+    plus the value stored in register V0. It enables relative jumps 
+    that depend on the contents of V0.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_BNNN : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        cpu.pc = (opcode.nnn + cpu.v[0].toUInt()).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_CXKK.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_CXKK.kt
@@ -1,0 +1,26 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: Cxkk - RND Vx, byte
+    Set Vx = random byte AND kk.
+
+    The interpreter generates a random number from 0 to 255,
+    performs a bitwise AND with the immediate kk value, and stores
+    the result in register Vx.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_CXKK : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        val x = opcode.x.toInt()
+        val rnd = (0..255).random().toUByte()
+        cpu.v[x] = rnd and opcode.kk
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_DXYN.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_DXYN.kt
@@ -1,0 +1,34 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: DXYN - DRW Vx, Vy, nibble
+    Display n-byte sprite starting at memory location I at (Vx, Vy), set VF = collision.
+
+    The interpreter reads n bytes from memory starting at address I.
+    These bytes are drawn as sprites at coordinates (Vx, Vy).
+    Drawing is done using XOR, and if any screen pixels are flipped from
+    set to unset, VF is set to 1 (indicating collision).
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_DXYN : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        val x = cpu.v[opcode.x.toInt()].toInt()
+        val y = cpu.v[opcode.y.toInt()].toInt()
+        val height = opcode.n.toInt()
+
+        val sprite = ByteArray(height) { row ->
+            core.memory.getByte((cpu.index + row.toUInt()).toUShort()).toByte()
+        }
+
+        val collision = core.display.drawSprite(x, y, sprite)
+        cpu.v[0xF] = if (collision) 1u else 0u
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_EX9E.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_EX9E.kt
@@ -1,0 +1,24 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: EX9E - SKP Vx
+    Skip next instruction if key with the value of Vx is pressed.
+
+    The instruction checks the keyboard input using the value in register Vx.
+    If the key corresponding to Vx is currently being pressed, the program
+    counter is increased by 4 (skip next instruction), otherwise by 2.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_EX9E : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        val x = opcode.x.toInt()
+        cpu.pc = (cpu.pc + (if (core.keyboard.isKeyPressed(cpu.v[x].toInt())) 4u else 2u)).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_EXA1.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_EXA1.kt
@@ -1,0 +1,25 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: EXA1 - SKNP Vx
+    Skip next instruction if key with the value of Vx is not pressed.
+
+    This instruction checks the keyboard state.
+    If the key stored in Vx is *not* currently pressed,
+    the program counter is increased by 4 (skipping the next instruction).
+    Otherwise, it proceeds normally to the next instruction (adds 2).
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_EXA1 : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        val x = opcode.x.toInt()
+        cpu.pc = (cpu.pc + (if (!core.keyboard.isKeyPressed(cpu.v[x].toInt())) 4u else 2u)).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_FX07.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_FX07.kt
@@ -1,0 +1,23 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: FX07 - LD Vx, DT
+    Set Vx = delay timer value.
+
+    The value of the delay timer (DT) is stored into register Vx.
+    This is useful for time-based operations or polling timer state.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_FX07 : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        cpu.v[opcode.x.toInt()] = core.timers.delayTimer
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_FX0A.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_FX0A.kt
@@ -1,0 +1,24 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: FX0A - LD Vx, K
+    Wait for a key press, store the value of the key in Vx.
+
+    All execution halts until a key is pressed. Once a key is pressed,
+    its index (0 to 15) is stored into register Vx.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_FX0A : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        val key = core.keyboard.waitForKeyPress()
+        cpu.v[opcode.x.toInt()] = key.toUByte()
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_FX15.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_FX15.kt
@@ -1,0 +1,22 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: FX15 - LD DT, Vx
+    Set delay timer = Vx.
+
+    The value stored in register Vx is assigned to the delay timer. 
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_FX15 : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        core.timers.delayTimer = cpu.v[opcode.x.toInt()]
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_FX18.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_FX18.kt
@@ -1,0 +1,23 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: FX18 - LD ST, Vx
+    Set sound timer = Vx.
+
+    This instruction sets the value of the sound timer (ST) to the value stored in register Vx.
+    While ST is greater than 0, the CHIP-8 buzzer is typically activated (on original hardware).
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_FX18 : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        core.timers.soundTimer = cpu.v[opcode.x.toInt()]
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_FX1E.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_FX1E.kt
@@ -1,0 +1,22 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: FX1E - ADD I, Vx
+
+    Adds the value in register Vx to the index register I.
+    The result is stored back in I.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_FX1E : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        cpu.index = (cpu.index + cpu.v[opcode.x.toInt()].toUInt()).toUShort()
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_FX29.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_FX29.kt
@@ -1,0 +1,25 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: FX29 - LD F, Vx
+    Set I = location of sprite for digit Vx.
+
+    Each digit (0–F) has a predefined 5-byte sprite stored in memory starting at 0x000.
+    To locate the sprite, we multiply the digit value by 5.
+    This sets the index register I to the memory address of the corresponding sprite.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_FX29 : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        val digit = cpu.v[opcode.x.toInt()].toInt()
+        cpu.index = (digit * 5).toUShort()
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_FX33.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_FX33.kt
@@ -1,0 +1,28 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: FX33 - LD B, Vx
+    Store Binary-Coded Decimal (BCD) representation of Vx in memory locations I, I+1, and I+2.
+
+    The interpreter converts the value of Vx into its BCD format:
+        - The hundreds digit is stored at memory[I]
+        - The tens digit is stored at memory[I + 1]
+        - The ones digit is stored at memory[I + 2]
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_FX33 : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        val value = cpu.v[opcode.x.toInt()].toInt()
+        core.memory.setByte(cpu.index, (value / 100).toUByte())                         // Hundreds
+        core.memory.setByte((cpu.index + 1u).toUShort(), ((value / 10) % 10).toUByte()) // Tens
+        core.memory.setByte((cpu.index + 2u).toUShort(), (value % 10).toUByte())        // Ones
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_FX55.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_FX55.kt
@@ -1,0 +1,25 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: FX55 - LD [I], Vx
+    Store registers V0 through Vx in memory starting at location I.
+
+    The interpreter copies the values of registers V0 through Vx (inclusive)
+    into memory starting at the address in register I.
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_FX55 : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        for (i in 0..opcode.x.toInt()) {
+            core.memory.setByte((cpu.index + i.toUInt()).toUShort(), cpu.v[i])
+        }
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_FX65.kt
+++ b/shared/src/commonMain/kotlin/com/fakhrirasyids/chemu/data/instruction/Instruction_FX65.kt
@@ -1,0 +1,25 @@
+package com.fakhrirasyids.chemu.data.instruction
+
+import com.fakhrirasyids.chemu.domain.CPU
+import com.fakhrirasyids.chemu.domain.Core
+import com.fakhrirasyids.chemu.domain.OPCode
+import com.fakhrirasyids.chemu.domain.instruction.Instruction
+
+/*
+    Author: @fakhrirasyids
+
+    Instruction: FX65 - LD Vx, [I]
+    Read registers V0 through Vx from memory starting at location I.
+
+    The interpreter reads values from memory starting at the address in register I
+    into registers V0 through Vx (inclusive).
+*/
+@OptIn(ExperimentalUnsignedTypes::class)
+class Instruction_FX65 : Instruction {
+    override fun execute(core: Core, cpu: CPU, opcode: OPCode) {
+        for (i in 0..opcode.x.toInt()) {
+            cpu.v[i] = core.memory.getByte((cpu.index + i.toUInt()).toUShort())
+        }
+        cpu.pc = (cpu.pc + 2u).toUShort()
+    }
+}


### PR DESCRIPTION
List of CHIP-8 Instructions (ref: http://devernay.free.fr/hacks/chip8/C8TECH10.HTM):
- `0NNN` = to call machine code routine at `nnn` (ignored by modern interpreters)
- `00E0` = to clear the display
- `00EE` = to return from a subroutine
- `1NNN` = to jump to address `nnn`
- `2NNN` = to call subroutine at `nnn`
- `3XKK` = to skip next instruction if `Vx == kk`
- `4XKK` = to skip next instruction if `Vx != kk`
- `5XY0` = to skip next instruction if `Vx == Vy`
- `6XKK` = to set `Vx = kk`
- `7XKK` = to add `kk` to `Vx`
- `8XY0` = to set `Vx = Vy`
- `8XY1` = to set `Vx = Vx OR Vy`
- `8XY2` = to set `Vx = Vx AND Vy`
- `8XY3` = to set `Vx = Vx XOR Vy`
- `8XY4` = to add `Vy` to `Vx`, set `VF = carry`
- `8XY5` = to subtract `Vy` from `Vx`, set `VF = NOT borrow`
- `8XY6` = to shift `Vx` right by 1, set `VF = LSB`
- `8XY7` = to subtract `Vx` from `Vy`, set `VF = NOT borrow`
- `8XYE` = to shift `Vx` left by 1, set `VF = MSB`
- `9XY0` = to skip next instruction if `Vx != Vy`
- `ANNN` = to set index register `I = nnn`
- `BNNN` = to jump to address `nnn + V0`
- `CXKK` = to set `Vx = random byte AND kk`
- `DXYN` = to draw sprite at (`Vx`, `Vy`) with height `n`, set `VF = collision`
- `EX9E` = to skip next instruction if key in `Vx` is pressed
- `EXA1` = to skip next instruction if key in `Vx` is not pressed
- `FX07` = to set `Vx = delay timer`
- `FX0A` = to wait for key press and store result in `Vx`
- `FX15` = to set delay timer = `Vx`
- `FX18` = to set sound timer = `Vx`
- `FX1E` = to add `Vx` to index register `I`
- `FX29` = to set `I = location of sprite for digit in Vx`
- `FX33` = to store BCD of `Vx` in memory at `I`, `I+1`, `I+2`
- `FX55` = to store registers `V0` through `Vx` in memory starting at `I`
- `FX65` = to load registers `V0` through `Vx` from memory starting at `I`